### PR TITLE
Validate that the key exists before using it

### DIFF
--- a/indigraphs.py
+++ b/indigraphs.py
@@ -281,8 +281,12 @@ def run():
             item_type = 'variable'
             folder = 'variables'
         else:
-            item_type = myIndigoData['type'][indigo_id]
-            folder = myIndigoData['folder'][indigo_id]
+        # If a reporting device is deleted it will error, so check if it exists
+            if (indigo_id in myIndigoData['type'] and indigo_id in myIndigoData['folder']):
+                item_type = myIndigoData['type'][indigo_id]
+                folder = myIndigoData['folder'][indigo_id]
+            else:
+                continue
         item_name = myIndigoData[table_type][indigo_id]
         if USE_GRAPHITE:
             # You could do something else with the Metric here, but what? :)


### PR DESCRIPTION
I deleted a Thermostat device in indigo, and shortly after indigraphs stopped working with the following error:

```
indigraphs.py: 968805641
Exception Traceback (most recent call shown last):

     indigraphs.py, line 313, at top level
     indigraphs.py, line 284, in run
KeyError: 968805641
```

After some investigation it appears it was trying to access a key that didn't exist. I added some checking to skip items if this is the case. After making the change it immediately started working and recovered all of my metrics:

```
[Indigraphs] Metrics Updated: 5881, Rows Skipped: 20846, Tables Scanned: 69
```

Thanks!
Andreas